### PR TITLE
Add sha256

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ IsoBuster, Hashcalc and SFOInfo are replaced by the `redump_psp.py` script.
 
 Given an ISO file, it will generate a pre-filled Redump submission, containing:
 - File size
-- Hashes (MD5, CRC32, SHA1)
+- Hashes (MD5, CRC32, SHA1, SHA256)
 - ISO PVD Hexdump
 - SFO information
 
@@ -54,9 +54,10 @@ Ring Codes:
 
 HashCalc Info:
 [code]
-MD5:   dd60041bfb6d677fdaacd2cf9cb6d84a
-SHA1:  88a19042041ff368b9cb887432cb5255c654c33c
-CRC32: 83adb164
+MD5:    dd60041bfb6d677fdaacd2cf9cb6d84a
+SHA1:   88a19042041ff368b9cb887432cb5255c654c33c
+CRC32:  83adb164
+SHA256: 7a9a04d89c1867b7f0ce4e9358b78ff52ec0a6612dc3a15511a3aaa5b1ef9cb4 
 [/code]
 
 Primary Volume Descriptor (PVD)

--- a/redump_psp.py
+++ b/redump_psp.py
@@ -37,14 +37,17 @@ def gen_hashes(filestream):
     prev_crc32 = 0
     sha1 = hashlib.sha1()
     md5 = hashlib.md5()
+    sha256 = hashlib.sha256()
     for piece in read_in_chunks(filestream, 0x10000):
         prev_crc32 = zlib.crc32(piece, prev_crc32)
         sha1.update(piece)
         md5.update(piece)
+        sha256.update(piece)
 
     return (format(prev_crc32 & 0xFFFFFFFF, 'x').zfill(8),
             sha1.hexdigest().zfill(40),
-            md5.hexdigest().zfill(32))
+            md5.hexdigest().zfill(32),
+            sha256.hexdigest())
 
 
 def get_pvd_dump(filestream):
@@ -71,7 +74,7 @@ def gen_psp_redump(iso, out):
 
     dump = TEMPLATE.format(
         size_mb=size_mb, size_b=size_b,
-        md5=hashes[2], sha1=hashes[1], crc32=hashes[0],
+        md5=hashes[2], sha1=hashes[1], crc32=hashes[0], sha256=hashes[3],
         pvd_hexdump=pvd_dump, sfo_info=sfo_info)
     if out:
         with open(out, 'w', encoding='utf8') as f:

--- a/redump_psp_template.py
+++ b/redump_psp_template.py
@@ -25,6 +25,7 @@ HashCalc Info:
 MD5:   {md5}
 SHA1:  {sha1}
 CRC32: {crc32}
+SHA256: {sha256}
 [/code]
 
 Primary Volume Descriptor (PVD)

--- a/redump_psp_template.py
+++ b/redump_psp_template.py
@@ -22,9 +22,9 @@ Ring Codes:
 
 HashCalc Info:
 [code]
-MD5:   {md5}
-SHA1:  {sha1}
-CRC32: {crc32}
+MD5:    {md5}
+SHA1:   {sha1}
+CRC32:  {crc32}
 SHA256: {sha256}
 [/code]
 


### PR DESCRIPTION
No-Intro, which dats UMD Video, requires SHA256. 
Also, it's a good idea to include it even though Redump doesn't require it since the other hash algos are insecure.